### PR TITLE
Avoid $navitem being null

### DIFF
--- a/classes/plugininfo.php
+++ b/classes/plugininfo.php
@@ -97,7 +97,7 @@ class plugininfo extends plugin implements
         // navigation may be the key.
         $navbar = $PAGE->navbar->get_items();
         $suggestedlocation = '';
-        while (count($navbar) >= 0) {
+        while (count($navbar) > 0) {
             $navitem = array_pop($navbar);
             if ($navitem->key != 'modedit') {
                 $suggestedlocation = $navitem->text;


### PR DESCRIPTION
When $navbar is an empty array, $navitem will be null, resulting in an error when reading $navitem->key in L102